### PR TITLE
Add missing data module and fix static file serving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ frontend/node_modules/
 frontend/dist/
 
 # Data
-data/
+/data/
 *.db
 
 # IDE

--- a/backend/src/data/mod.rs
+++ b/backend/src/data/mod.rs
@@ -1,0 +1,2 @@
+pub mod schema;
+pub mod weights;

--- a/backend/src/data/schema.rs
+++ b/backend/src/data/schema.rs
@@ -1,0 +1,28 @@
+//! SQLite database schema initialization.
+
+use rusqlite::{Connection, Result};
+
+/// Open (or create) the SQLite database and ensure the schema exists.
+pub fn open_database(path: &str) -> Result<Connection> {
+    let conn = Connection::open(path)?;
+
+    // Enable WAL mode for better concurrent read performance.
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS weights (
+            version  INTEGER PRIMARY KEY,
+            data     BLOB NOT NULL,
+            created  TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS games (
+            id       INTEGER PRIMARY KEY,
+            pgn      TEXT NOT NULL,
+            result   TEXT NOT NULL,
+            created  TEXT NOT NULL DEFAULT (datetime('now'))
+        );",
+    )?;
+
+    Ok(conn)
+}

--- a/backend/src/data/weights.rs
+++ b/backend/src/data/weights.rs
@@ -1,0 +1,42 @@
+//! Load and save evaluation weights from the database.
+
+use crate::engine::eval::EvalWeights;
+use rusqlite::{Connection, Result};
+
+/// Load the latest weight version from the database.
+/// Returns `Ok(None)` if no weights have been saved yet.
+pub fn load_latest_weights(conn: &Connection) -> Result<Option<(u32, EvalWeights)>> {
+    let mut stmt = conn.prepare(
+        "SELECT version, data FROM weights ORDER BY version DESC LIMIT 1",
+    )?;
+
+    let mut rows = stmt.query([])?;
+
+    match rows.next()? {
+        Some(row) => {
+            let version: u32 = row.get(0)?;
+            let data: Vec<u8> = row.get(1)?;
+            let weight_vec: Vec<f64> = rmp_serde::from_slice(&data)
+                .map_err(|e| rusqlite::Error::FromSqlConversionFailure(
+                    1,
+                    rusqlite::types::Type::Blob,
+                    Box::new(e),
+                ))?;
+            let weights = EvalWeights::from_vec(&weight_vec)
+                .map_err(|e| rusqlite::Error::InvalidParameterName(e))?;
+            Ok(Some((version, weights)))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Save weights to the database with the given version number.
+pub fn save_weights(conn: &Connection, version: u32, weights: &EvalWeights) -> Result<()> {
+    let data = rmp_serde::to_vec(&weights.to_vec())
+        .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
+    conn.execute(
+        "INSERT OR REPLACE INTO weights (version, data) VALUES (?1, ?2)",
+        rusqlite::params![version, data],
+    )?;
+    Ok(())
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -33,7 +33,7 @@ struct Args {
     search_log: bool,
 
     /// Path to frontend static files
-    #[arg(long, default_value = "../frontend/dist")]
+    #[arg(long, default_value = "frontend/dist")]
     frontend_dir: String,
 }
 


### PR DESCRIPTION
- Create backend/src/data/ module with schema (SQLite init) and weights (load/save evaluation weights via MessagePack serialization)
- Fix .gitignore: use /data/ to only ignore top-level data dir, not backend/src/data/ source files
- Fix default frontend_dir path from ../frontend/dist to frontend/dist to match the project root working directory